### PR TITLE
fix: check and handle errors for stated type/actual type mismatch cases for string type parameters

### DIFF
--- a/lib/fetchParams.js
+++ b/lib/fetchParams.js
@@ -132,7 +132,7 @@ function getOptionalParams(req, option_expressions) {
       options[key] = val !== undefined ? val : keyInfo.defaultVal;
       continue;
     } else if (keyInfo.type === 'string') {
-      options[key] = val !== undefined ? val.replace(/\u0000/g, '') : keyInfo.defaultVal;
+      options[key] = typeof val === 'string' ? val.replace(/\u0000/g, '') : keyInfo.defaultVal;
       continue;
     }
 
@@ -274,6 +274,12 @@ function requiredParameter(req, required_expressions) {
       options[key] = func(val);
 
     } else if (keyInfo.type && keyInfo.type === 'string') {
+      if (typeof val !== 'string') {
+        err = new Error('The parameter value is not a string : ' + key);
+        err.code = 400;
+        break;
+      }
+
       options[key] = (val || '').replace(/\u0000/g, '');
     } else {
       options[key] = val;

--- a/test/fetch.optional.js
+++ b/test/fetch.optional.js
@@ -156,6 +156,80 @@ describe('It can ', function() {
       });
   });
 
+  describe('fetch optional parameters with type: string, input: not string', function () {
+    beforeEach(function(done){
+      app.post('/path', function(req, res, next) {
+        var optional = ['string:content']
+          , options = req.fetchParameter([], optional);
+
+        if (req.checkParamErr(options)) return next(options);
+
+        return res.send(options);
+      });
+
+      app.use(function(err, req, res, next) {
+        return res.status(err.code).send(err.message);
+      });
+      done();
+    })
+
+    function testStringTypeParam ({body, done}) {
+      request(app)
+        .post('/path')
+        .send(body)
+        .expect(200, function(err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).to.deep.equal({});
+          done();
+        });
+    }
+
+    var notStringValues = [1, true, undefined, null, NaN, {}]
+    notStringValues.forEach((args, i) => {
+      var body = { content: args }
+      it(`#${i}: value = ${args}`, function (done) {
+        testStringTypeParam ({body, done})
+      });
+    });
+  });
+
+  describe('fetch optional parameters with type: string and default value and input: not string', function () {
+    beforeEach(function(done){
+      app.post('/path', function(req, res, next) {
+        var optional = ['string:stream|=N']
+          , options = req.fetchParameter([], optional);
+
+        if (req.checkParamErr(options)) return next(options);
+
+        return res.send(options);
+      });
+
+      app.use(function(err, req, res, next) {
+        return res.status(err.code).send(err.message);
+      });
+      done();
+    })
+
+    function testStringTypeParam ({body, done}) {
+      request(app)
+        .post('/path')
+        .send(body)
+        .expect(200, function(err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).to.deep.equal({ stream: 'N' });
+          done();
+        });
+    }
+
+    var notStringValues = [1, true, undefined, null, NaN, {}]
+    notStringValues.forEach((args, i) => {
+      var body = { content: args }
+      it(`#${i}: value = ${args}`, function (done) {
+        testStringTypeParam ({body, done})
+      });
+    });
+  });
+
   it('fetch optional parameters input number 0', function(done) {
     app.get('/path', function(req, res, next) {
       var required = []


### PR DESCRIPTION
* Check actual values' types of parameters stated as type string
* Add error case for when the actual value is not a string
  *  handle typeerrors from calling String.prototype.replace on a value that is not a string
  * improve type checking/error handling behavior consistency  (as using other stated types (int, float, number, int32, uint32) will check the actual type and return customized errors)
* Add test cases for checking parameters stated as type string